### PR TITLE
Add logging in generateBuildInfo.js

### DIFF
--- a/generateBuildInfo.js
+++ b/generateBuildInfo.js
@@ -21,6 +21,7 @@ function getLatestTag() {
     try {
         return execSync('git describe --tags --abbrev=0 2>/dev/null').toString().trim();
     } catch (error) {
+        console.error('Error retrieving the latest tag:', error);
         return null;
     }
 }
@@ -36,6 +37,7 @@ function getCurrentVersionString(currentVersion, latestTag) {
         }
     }
 
+    console.warn(`No matching tag found for current version ${currentVersion}. Returning default version.`);
     return `${currentMajor}.${currentMinor}.0`;
 }
 


### PR DESCRIPTION
This pull request adds improved error handling and logging to the `generateBuildInfo.js` script. The changes help make it easier to diagnose issues when retrieving git tags and version information.

Error handling and logging improvements:

* Added a console error message in `getLatestTag()` to log failures when retrieving the latest git tag.
* Added a console warning in `getCurrentVersionString()` to notify when no matching tag is found for the current version, and the default version is returned.