### PR TITLE
Update manually actions/github-script version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Create tag
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ env.VEMPAIN_ACTION_TOKEN }}
           script: |
@@ -165,7 +165,7 @@ jobs:
             })
 
       - name: Create GitHub Release
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ env.VEMPAIN_ACTION_TOKEN }}
           script: |


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use the latest major version of the `actions/github-script` action. This ensures compatibility with the latest features and security updates.

Dependency updates:

* Updated the `actions/github-script` action from version `v8` to `v9` in the "Create tag" and "Create GitHub Release" workflow steps in `.github/workflows/ci.yaml`. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL156-R156) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL168-R168)