### PR TITLE
All mocks are placed in the <rootDir>/__mocks__ directory

### DIFF
--- a/__mocks__/resolveApiUrl.ts
+++ b/__mocks__/resolveApiUrl.ts
@@ -1,0 +1,3 @@
+export function resolveApiUrl(): string {
+    return process.env.VITE_APP_API_URL ?? "";
+}

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less)$" : "<rootDir>/__mocks__/styleMock.js",
-      "^(.*)/resolveApiUrl$" : "$1/__mocks__/resolveApiUrl"
+      "^(.*)/resolveApiUrl$" : "<rootDir>/__mocks__/resolveApiUrl"
     }
   },
   "repository": {


### PR DESCRIPTION
This pull request introduces a mock implementation for the `resolveApiUrl` utility and updates the Jest configuration to correctly map imports to this new mock. These changes help ensure that tests use a controlled environment variable for the API URL, improving test reliability.

Testing improvements:

* Added a mock implementation of `resolveApiUrl` in `__mocks__/resolveApiUrl.ts` that returns the value of `process.env.VITE_APP_API_URL` or an empty string if not set.
* Updated the `moduleNameMapper` in `package.json` so that imports of `resolveApiUrl` are mapped to the new mock file, ensuring consistent behavior in tests.