### PR TITLE
Fix filegroup listing

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -22,8 +22,9 @@
   returned by the backend.
 - Snake_case is mandatory for all JSON payload keys in Vempain APIs; do not add camelCase request/response keys when creating frontend models or serializers.
 - Do **not** “React-ify” API models into camelCase inside components unless you are intentionally mapping them.
-- File-group and pageable APIs are server-driven: Ant Design tables stay 1-based, backend requests are 0-based (`page: currentPage - 1`). See
-  `src/components/files/FileGroups.tsx` and `src/components/files/ImageFiles.tsx`.
+- File-group and pageable APIs are server-driven: Ant Design tables stay 1-based, backend requests are 0-based (`page: tablePage - 1`). Send one snake_case
+  `PagedRequest` body to `POST /file-groups/paged`; use the shared `findPageable()` client method. Table pagination, sorting, and column filter changes update
+  that request object and trigger a new fetch.
 
 ## TypeScript constraints specific to this repo
 
@@ -70,7 +71,7 @@
 ## Practical gotchas for agents
 
 - When adding a new list screen, prefer reusing `commonColumns.tsx` and `FileDetails` before inventing new table column renderers.
-- When adding sorting/search to Ant Design tables backed by the server, copy the `FileGroups.tsx` pattern: local `sortField/sortOrder/searchTerm/caseSensitive`
-  state, then fetch in a `useCallback` + `useEffect` pair.
+- When adding sorting/search to Ant Design tables backed by the server, keep the request state in one `PagedRequest` object and fetch it in a
+  `useCallback` + `useEffect` pair. Do not fetch an unpaged list and filter it in the browser.
 - When adding routes, check for matching `NavLink`s in `TopBar.tsx`; the menu is conditional on `userSession`.
 - Footer/version text comes from `src/buildInfo.json` plus `VITE_APP_VEMPAIN_*` env vars in `src/main/BottomFooter.tsx`.

--- a/src/__tests__/services/FileGroupAPI.test.ts
+++ b/src/__tests__/services/FileGroupAPI.test.ts
@@ -37,7 +37,7 @@ describe("FileGroupAPI", () => {
         const pagedRequest: PagedRequest = {
             page: 0,
             size: 50,
-            sort_by: "path",
+            sort_by: "file_count",
             direction: "ASC",
         };
 

--- a/src/__tests__/services/FileGroupAPI.test.ts
+++ b/src/__tests__/services/FileGroupAPI.test.ts
@@ -33,7 +33,7 @@ describe("FileGroupAPI", () => {
         expect(response).toEqual(responseData);
     });
 
-    it("getFileGroups POSTs PagedRequest to relative paged endpoint and returns PagedResponse<FileGroupListResponse>", async () => {
+    it("findPageable POSTs PagedRequest to relative paged endpoint and returns PagedResponse<FileGroupListResponse>", async () => {
         const pagedRequest: PagedRequest = {
             page: 0,
             size: 50,
@@ -60,7 +60,7 @@ describe("FileGroupAPI", () => {
         };
         axiosMock.post.mockResolvedValueOnce({data: responseData});
 
-        const response = await fileGroupAPI.getFileGroups(pagedRequest);
+        const response = await fileGroupAPI.findPageable(pagedRequest);
 
         expect(setAuthorizationHeaderSpy).toHaveBeenCalledTimes(1);
         expect(axiosMock.defaults.headers.post["Content-Type"]).toBe("application/json;charset=utf-8");
@@ -68,4 +68,3 @@ describe("FileGroupAPI", () => {
         expect(response).toEqual(responseData);
     });
 });
-

--- a/src/components/data/PublishGpsTimeSeries.tsx
+++ b/src/components/data/PublishGpsTimeSeries.tsx
@@ -33,7 +33,7 @@ export function PublishGpsTimeSeries() {
             search: search.trim() === "" ? undefined : search,
             case_sensitive: false,
         };
-        fileGroupAPI.getFileGroups(pagedRequest)
+        fileGroupAPI.findPageable(pagedRequest)
                 .then((data) => {
                     if (requestId !== requestIdRef.current) {
                         return;

--- a/src/components/files/FileGroups.tsx
+++ b/src/components/files/FileGroups.tsx
@@ -1,8 +1,8 @@
-import {Button, Form, Input, message, Modal, Popconfirm, Select, Space, Spin, Switch, Table, Typography} from "antd";
-import {DeleteOutlined, EditOutlined, PlusOutlined, UploadOutlined} from "@ant-design/icons";
-import {useCallback, useEffect, useMemo, useState} from "react";
+import {Button, Form, Input, type InputRef, message, Modal, Popconfirm, Select, Space, Spin, Table, Typography} from "antd";
+import {DeleteOutlined, EditOutlined, PlusOutlined, SearchOutlined, UploadOutlined} from "@ant-design/icons";
+import {useCallback, useEffect, useMemo, useRef, useState} from "react";
 import type {ColumnsType} from "antd/es/table";
-import type {SorterResult, SortOrder} from "antd/es/table/interface";
+import type {FilterDropdownProps, FilterValue, SorterResult, TableColumnType} from "antd/es/table/interface";
 import {
     archiveFileAPI,
     audioFileAPI,
@@ -34,14 +34,15 @@ export function FileGroups() {
     // Table state
     const [loading, setLoading] = useState<boolean>(true);
     const [groups, setGroups] = useState<FileGroupListResponse[]>([]);
-    const [currentPage, setCurrentPage] = useState<number>(1);
-    const [pageSize, setPageSize] = useState<number>(10);
+    const [pagedRequest, setPagedRequest] = useState<PagedRequest>({
+        page: 0,
+        size: 10,
+        sort_by: "path",
+        direction: "ASC",
+        case_sensitive: false
+    });
     const [totalElements, setTotalElements] = useState<number>(0);
-    const [sortField, setSortField] = useState<string>("path");
-    const [sortOrder, setSortOrder] = useState<SortOrder>("ascend");
-    const [searchInput, setSearchInput] = useState<string>("");
-    const [searchTerm, setSearchTerm] = useState<string | undefined>(undefined);
-    const [caseSensitive, setCaseSensitive] = useState<boolean>(false);
+    const searchInput = useRef<InputRef>(null);
 
     // Edit/Create modal state
     const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
@@ -162,30 +163,33 @@ export function FileGroups() {
         setSelectedFiles(prev => prev.filter(f => f.id !== id));
     };
 
-    const fetchGroups = useCallback((page: number = currentPage, size: number = pageSize) => {
+    const fetchGroups = useCallback((request: PagedRequest = pagedRequest) => {
         setLoading(true);
-
-        const pagedRequest: PagedRequest = {
-            page: page - 1,
-            size: size,
-            sort_by: sortField,
-            direction: sortOrder === "descend" ? "DESC" : "ASC",
-            search: searchTerm,
-            case_sensitive: caseSensitive
-        };
-        fileGroupAPI.getFileGroups(pagedRequest)
+        fileGroupAPI.findPageable(request)
                 .then((res) => {
                     setGroups(res.content ?? []);
                     setTotalElements(res.total_elements ?? 0);
-                    setCurrentPage((res.page ?? (page - 1)) + 1);
-                    setPageSize(res.size ?? size);
+                    setPagedRequest(previous => {
+                        const responsePage = res.page ?? request.page;
+                        const responseSize = res.size ?? request.size;
+
+                        if (previous.page === responsePage && previous.size === responseSize) {
+                            return previous;
+                        }
+
+                        return {
+                            ...previous,
+                            page: responsePage,
+                            size: responseSize
+                        };
+                    });
                 })
                 .catch((err) => {
                     console.error("Failed to fetch file groups:", err);
                     message.error(t("FileGroups.messages.fetchError", {defaultValue: "Failed to load file groups"}));
                 })
                 .finally(() => setLoading(false));
-    }, [caseSensitive, currentPage, pageSize, searchTerm, sortField, sortOrder, t]);
+    }, [pagedRequest, t]);
 
     useEffect(() => {
         fetchGroups();
@@ -322,41 +326,77 @@ export function FileGroups() {
         setPublishModalOpen(true);
     }, [publishForm]);
 
+    const getColumnSearchProps = useCallback((dataIndex: "path" | "group_name" | "description"): TableColumnType<FileGroupListResponse> => ({
+        filterDropdown: ({setSelectedKeys, selectedKeys, confirm, clearFilters, close}: FilterDropdownProps) => (
+                <div style={{padding: 8}} onKeyDown={(event) => event.stopPropagation()}>
+                    <Input
+                            ref={searchInput}
+                            value={selectedKeys[0]}
+                            onChange={(event) => setSelectedKeys(event.target.value ? [event.target.value] : [])}
+                            onPressEnter={() => confirm()}
+                            style={{marginBottom: 8, display: "block"}}
+                    />
+                    <Space>
+                        <Button type="primary" size="small" icon={<SearchOutlined/>} onClick={() => confirm()}>
+                            {t("Common.search", {defaultValue: "Search"})}
+                        </Button>
+                        <Button size="small" onClick={() => {
+                            clearFilters?.();
+                            confirm();
+                            close();
+                        }}>
+                            {t("Common.reset", {defaultValue: "Reset"})}
+                        </Button>
+                    </Space>
+                </div>
+        ),
+        filterIcon: (filtered: boolean) => <SearchOutlined style={{color: filtered ? "#1677ff" : undefined}}/>,
+        filterDropdownProps: {
+            onOpenChange: (visible: boolean) => {
+                if (visible) {
+                    setTimeout(() => searchInput.current?.select(), 100);
+                }
+            }
+        },
+        dataIndex
+    }), [t]);
+
     const columns: ColumnsType<FileGroupListResponse> = useMemo(() => [
         {
             title: t("FileGroups.columns.path.title", {defaultValue: "Path"}),
             dataIndex: "path",
             key: "path",
             sorter: true,
-            sortOrder: sortField === "path" ? sortOrder : undefined,
+            sortOrder: pagedRequest.sort_by === "path" ? (pagedRequest.direction === "DESC" ? "descend" : "ascend") : undefined,
+            ...getColumnSearchProps("path"),
         },
         {
             title: t("FileGroups.columns.path.gallery-id", {defaultValue: "Gallery ID"}),
             dataIndex: "gallery_id",
             key: "gallery-id",
-            sorter: true,
-            sortOrder: sortField === "gallery_id" ? sortOrder : undefined,
+            sorter: false,
         },
         {
             title: t("FileGroups.columns.group_name.title", {defaultValue: "Group name"}),
             dataIndex: "group_name",
             key: "group_name",
             sorter: true,
-            sortOrder: sortField === "group_name" ? sortOrder : undefined,
+            sortOrder: pagedRequest.sort_by === "group_name" ? (pagedRequest.direction === "DESC" ? "descend" : "ascend") : undefined,
+            ...getColumnSearchProps("group_name"),
         },
         {
             title: t("FileGroups.columns.description.title", {defaultValue: "Description"}),
             dataIndex: "description",
             key: "description",
             sorter: true,
-            sortOrder: sortField === "description" ? sortOrder : undefined,
+            sortOrder: pagedRequest.sort_by === "description" ? (pagedRequest.direction === "DESC" ? "descend" : "ascend") : undefined,
+            ...getColumnSearchProps("description"),
         },
         {
             title: t("FileGroups.columns.file_count.title", {defaultValue: "Files"}),
             dataIndex: "file_count",
             key: "file_count",
-            sorter: true,
-            sortOrder: sortField === "file_count" ? sortOrder : undefined,
+            sorter: false,
             render: (_: unknown, record: FileGroupListResponse) => record.file_count ?? "",
         },
         {
@@ -389,7 +429,7 @@ export function FileGroups() {
                 );
             }
         }
-    ], [sortField, sortOrder, t, handleDelete, openEditModal, openPublishModal]);
+    ], [getColumnSearchProps, pagedRequest, t, handleDelete, openEditModal, openPublishModal]);
 
     const fileColumns: ColumnsType<FileResponse> = useMemo(() => [
         filenameColumn<FileResponse>((record) => {
@@ -419,31 +459,21 @@ export function FileGroups() {
 
     function handleTableChange(
             pagination: { current?: number; pageSize?: number },
-            _filters: Record<string, unknown>,
+            filters: Record<string, FilterValue | null>,
             sorter: SorterResult<FileGroupListResponse> | SorterResult<FileGroupListResponse>[]
     ) {
-        const nextPage = pagination.current ?? 1;
-        const nextSize = pagination.pageSize ?? pageSize;
-        setCurrentPage(nextPage);
-        setPageSize(nextSize);
-        if (!Array.isArray(sorter) && sorter.field) {
-            setSortField(toBackendSortField(sorter.field as string));
-            setSortOrder(sorter.order ?? "ascend");
-        } else {
-            setSortField("path");
-            setSortOrder("ascend");
-        }
-    }
-
-    const handleSearch = (value: string) => {
-        setSearchInput(value);
-        setSearchTerm(value || undefined);
-        setCurrentPage(1);
-    };
-
-    const handleCaseSensitiveChange = (checked: boolean) => {
-        setCaseSensitive(checked);
-        setCurrentPage(1);
+        const search = Object.values(filters)
+                .flatMap(value => value ?? [])
+                .find(value => typeof value === "string" && value.length > 0);
+        const nextSorter = !Array.isArray(sorter) && sorter.field ? sorter : undefined;
+        setPagedRequest(previous => ({
+            ...previous,
+            page: (pagination.current ?? 1) - 1,
+            size: pagination.pageSize ?? previous.size,
+            sort_by: toBackendSortField(nextSorter?.field as string | undefined),
+            direction: nextSorter?.order === "descend" ? "DESC" : "ASC",
+            search: typeof search === "string" ? search : undefined
+        }));
     };
 
     // openPublishModal is declared above columns/useMemo to avoid use-before-declare in hook deps.
@@ -491,20 +521,9 @@ export function FileGroups() {
     return (
             <Space vertical={true} style={{width: "95%", margin: 30}} size="large">
                 <Space style={{width: "95%", justifyContent: "space-between"}}>
-                    <Space align="center" size={16}>
-                        <Input.Search
-                                placeholder={t("FileGroups.search.placeholder", {defaultValue: "Search file groups"})}
-                                allowClear
-                                value={searchInput}
-                                onChange={(event) => setSearchInput(event.target.value)}
-                                onSearch={handleSearch}
-                                style={{minWidth: 260}}
-                        />
-                        <Space align="center">
-                            {t("FileGroups.search.caseSensitive", {defaultValue: "Case sensitive"})}
-                            <Switch size="small" checked={caseSensitive} onChange={handleCaseSensitiveChange}/>
-                        </Space>
-                    </Space>
+                    <Typography.Text type="secondary">
+                        {t("FileGroups.search.description", {defaultValue: "Use the column filters to search file groups."})}
+                    </Typography.Text>
                     <Button type="primary" icon={<PlusOutlined/>} onClick={openCreateModal}>
                         {t("FileGroups.actions.new", {defaultValue: "New group"})}
                     </Button>
@@ -516,8 +535,8 @@ export function FileGroups() {
                             dataSource={groups.map(g => ({...g, key: g.id}))}
                             loading={loading}
                             pagination={{
-                                current: currentPage,
-                                pageSize: pageSize,
+                                current: pagedRequest.page + 1,
+                                pageSize: pagedRequest.size,
                                 total: totalElements,
                                 showSizeChanger: true,
                                 pageSizeOptions: ['10', '20', '50', '100'],

--- a/src/components/files/FileGroups.tsx
+++ b/src/components/files/FileGroups.tsx
@@ -396,7 +396,8 @@ export function FileGroups() {
             title: t("FileGroups.columns.file_count.title", {defaultValue: "Files"}),
             dataIndex: "file_count",
             key: "file_count",
-            sorter: false,
+            sorter: true,
+            sortOrder: pagedRequest.sort_by === "file_count" ? (pagedRequest.direction === "DESC" ? "descend" : "ascend") : undefined,
             render: (_: unknown, record: FileGroupListResponse) => record.file_count ?? "",
         },
         {

--- a/src/models/responses/FileGroupResponse.ts
+++ b/src/models/responses/FileGroupResponse.ts
@@ -5,5 +5,5 @@ export interface FileGroupResponse {
     path: string;
     group_name: string;
     description: string;
-    files: FileResponse[]
+    files?: FileResponse[]
 }

--- a/src/services/FileGroupAPI.ts
+++ b/src/services/FileGroupAPI.ts
@@ -9,12 +9,10 @@ export class FileGroupAPI extends AbstractAPI<FileGroupRequest, FileGroupRespons
         return response.data;
     }
 
-    public async getFileGroups(pagedRequest: PagedRequest): Promise<PagedResponse<FileGroupListResponse>> {
+    public async findPageable(pagedRequest: PagedRequest): Promise<PagedResponse<FileGroupListResponse>> {
         this.setAuthorizationHeader();
         this.axiosInstance.defaults.headers.post["Content-Type"] = "application/json;charset=utf-8";
-
         const response = await this.axiosInstance.post<PagedResponse<FileGroupListResponse>>("paged", pagedRequest);
-
         return response.data;
     }
 }

--- a/src/testUtils/mockAuthFrontend.ts
+++ b/src/testUtils/mockAuthFrontend.ts
@@ -75,8 +75,8 @@ jest.mock("@vempain/vempain-auth-frontend", () => {
 
         public async findPageable(params?: Record<string, unknown>) {
             this.setAuthorizationHeader();
-            this.axiosInstance.defaults.headers.get["Content-Type"] = "application/json;charset=utf-8";
-            const response = await this.axiosInstance.get("", {params});
+            this.axiosInstance.defaults.headers.post["Content-Type"] = "application/json;charset=utf-8";
+            const response = await this.axiosInstance.post("paged", params);
             return response.data;
         }
 
@@ -118,5 +118,4 @@ jest.mock("@vempain/vempain-auth-frontend", () => {
         AbstractAPI: MockAbstractAPI,
     };
 }, {virtual: true});
-
 


### PR DESCRIPTION
This pull request refactors the file group table and API integration to use a unified, server-driven paging and filtering model. The main change is replacing separate local state variables for pagination, sorting, and search with a single `PagedRequest` object, ensuring the frontend always reflects the backend's paged API contract. The table now uses column-based filters for searching, and the API method `findPageable` replaces the previous `getFileGroups` method for consistency. Documentation and tests have been updated accordingly.

**Frontend Table Refactor and Filtering:**
* Refactored `FileGroups.tsx` to manage all table state (pagination, sorting, search) in a single `pagedRequest` object, removing separate state variables for each. Table now uses column filter dropdowns for searching, and updates the request object on any table interaction. The search input and case sensitivity switch above the table were removed in favor of column filters. [[1]](diffhunk://#diff-1ebf7592b9fdac971c7d10c17915db5b79465c78c680cd94ad365bbd1657dfa8L37-R45) [[2]](diffhunk://#diff-1ebf7592b9fdac971c7d10c17915db5b79465c78c680cd94ad365bbd1657dfa8L165-R192) [[3]](diffhunk://#diff-1ebf7592b9fdac971c7d10c17915db5b79465c78c680cd94ad365bbd1657dfa8R329-R400) [[4]](diffhunk://#diff-1ebf7592b9fdac971c7d10c17915db5b79465c78c680cd94ad365bbd1657dfa8L392-R433) [[5]](diffhunk://#diff-1ebf7592b9fdac971c7d10c17915db5b79465c78c680cd94ad365bbd1657dfa8L422-R477) [[6]](diffhunk://#diff-1ebf7592b9fdac971c7d10c17915db5b79465c78c680cd94ad365bbd1657dfa8L494-R527) [[7]](diffhunk://#diff-1ebf7592b9fdac971c7d10c17915db5b79465c78c680cd94ad365bbd1657dfa8L519-R540)

**API Method and Usage Updates:**
* Replaced `getFileGroups` with `findPageable` in `FileGroupAPI`, updating all usages and tests to POST the `PagedRequest` body to the `paged` endpoint. [[1]](diffhunk://#diff-6a8778e2b04f9effe38be8c00e216b515b67377f4b778482cdd8117aecc8cb48L12-L17) [[2]](diffhunk://#diff-26ad00c2272b99385b24e3db2c7810e13bcdae56f437a6721d7c6914737a8894L36-R40) [[3]](diffhunk://#diff-26ad00c2272b99385b24e3db2c7810e13bcdae56f437a6721d7c6914737a8894L63-L71) [[4]](diffhunk://#diff-c6ca58776e95105f421f078ad8e87fe7e07b8541b439cffab51a2c393121acd6L36-R36) [[5]](diffhunk://#diff-23bff6e4005aabbc7ced358a5882e5a08daedef7c5537a2e68e00d72a6251de6L78-R79)
* Updated the mock API in test utilities to match the new POST contract for `findPageable`.

**Documentation Improvements:**
* Updated `AGENTS.md` to document the new unified `PagedRequest` approach and discourage local filtering or fetching the full list client-side. [[1]](diffhunk://#diff-d00743dc4e878f258330deadcd4008e361276d760b58b672150c54bb1ac9758aL25-R27) [[2]](diffhunk://#diff-d00743dc4e878f258330deadcd4008e361276d760b58b672150c54bb1ac9758aL73-R75)

**Type and Model Adjustments:**
* Made the `files` field in `FileGroupResponse` optional to better align with paged list responses.

These changes simplify the codebase, improve consistency with backend APIs, and provide a more scalable approach to table filtering and paging.